### PR TITLE
유저매칭완료시 공인중개사는 요청조회 못하게 하는 기능구현

### DIFF
--- a/src/main/java/backend/zip/controller/matching/MatchController.java
+++ b/src/main/java/backend/zip/controller/matching/MatchController.java
@@ -45,9 +45,8 @@ public class MatchController {
 //    }
 
     @Operation(summary = "매물별매칭상태변경", description = "matchStatus인자에 해당값을 넣어주시면 됩니다." +
-                                                    "공인중개사가 매칭후보를 매칭확정 시키기 : MATCH_COMPLETE" +
                                                     "일반유저가 자기 매칭요청상태에서 +버튼 눌러서 찜하기 : MATCH_LIKE" +
-                                                    "일반유저가 최종적으로 매칭완료시키기 : MATCH_FINAL_COMPLETE")
+                                                    "일반유저가 최종적으로 매칭완료시키기 : MATCH_COMPLETE")
     @PatchMapping("/brokers/{matchingId}") // 엔드포인트 변경필요 비직관적임.
     public ApiResponse<MatchStatusResponse> matchCompleteBrokerItems(@PathVariable Long matchingId,
                                                                      @RequestParam MatchStatus matchStatus) {

--- a/src/main/java/backend/zip/domain/enums/MatchStatus.java
+++ b/src/main/java/backend/zip/domain/enums/MatchStatus.java
@@ -1,5 +1,5 @@
 package backend.zip.domain.enums;
 
 public enum MatchStatus {
-    WAITING,MATCH_COMPLETE,MATCH_LIKE,MATCH_FINAL_COMPLETE
+    WAITING,MATCH_LIKE,MATCH_COMPLETE
 }

--- a/src/main/java/backend/zip/domain/enums/RoomSize.java
+++ b/src/main/java/backend/zip/domain/enums/RoomSize.java
@@ -1,5 +1,5 @@
 package backend.zip.domain.enums;
 
 public enum RoomSize {
-    UNDER_FIVE,TEN,TWENTY,THIRTY,FORTY,FIFTY,OVER_SIXTY
+    UNDER_17, UNDER_66, UNDER_99, UNDER_132, UNDER_165, UNDER_198, OVER_198
 }

--- a/src/main/java/backend/zip/domain/user/UserItem.java
+++ b/src/main/java/backend/zip/domain/user/UserItem.java
@@ -27,6 +27,9 @@ public class UserItem {
     @Column(name = "dong")
     private String dong;
 
+    @Column(name = "is_matched")
+    private Boolean isMatched;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_option_id")
     @JsonManagedReference

--- a/src/main/java/backend/zip/domain/user/UserItem.java
+++ b/src/main/java/backend/zip/domain/user/UserItem.java
@@ -41,4 +41,8 @@ public class UserItem {
         }
         this.userOption = userOption;
     }
+
+    public void updateMatched(boolean b) {
+        this.isMatched = b;
+    }
 }

--- a/src/main/java/backend/zip/service/match/MatchServiceImpl.java
+++ b/src/main/java/backend/zip/service/match/MatchServiceImpl.java
@@ -56,6 +56,12 @@ public class MatchServiceImpl implements MatchService {
     @Override
     public Matching updateMatchStatus(Long matchId, MatchStatus matchStatus) {
         Matching matching = findMatch(matchId);
+        //만약 matchStatus가 MATCH_COMPLETE이면 userItem의 isMatched를 true로 변경해야함
+        if (matchStatus.equals(MatchStatus.MATCH_COMPLETE)) {
+            UserItem userItem = matching.getUserItem();
+            userItem.updateMatched(true);
+            userItemRepository.save(userItem);
+        }
         //안전한 방법은 아니지만 프론트에서 화면당 구분하여 호출한다면 예외발생날일은 없을거같은데요
         matching.updateMatchStatus(matchStatus);
         return matching;

--- a/src/main/java/backend/zip/service/userItem/UserItemServiceImpl.java
+++ b/src/main/java/backend/zip/service/userItem/UserItemServiceImpl.java
@@ -36,6 +36,7 @@ public class UserItemServiceImpl implements UserItemService{
         UserItem userItem = UserItem.builder()
                 .user(userRepository.findById(userId).orElseThrow())
                 .dong(dong)
+                .isMatched(false)
                 .build();
 
         // 옵션 저장 현수님 방법 차용
@@ -90,6 +91,10 @@ public class UserItemServiceImpl implements UserItemService{
         List<UserItem> userItems = userItemRepository.findAllByDong(dongName);
         //Map<String, List<UserItem>> userItemByDong = userItems.stream()
         //        .collect(Collectors.groupingBy(UserItem::getDong));
+        //만약 userItems의 isMatched가 true이면 리스트에서 제외하고 보냄
+        userItems = userItems.stream()
+                .filter(userItem -> !userItem.getIsMatched())
+                .collect(Collectors.toList());
         return UserItemByDongResponse.from(userItems);
     }
 }


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---
### 📝 작업 내용

- UserItem관련 데이터 초기화 다 수정 : bool 변수인 isMatched 추가하기때문
- 최종매칭시 공인중개사가 요청조회 못하게 기능구현


---

### ✏️ 관련 이슈(선택 사항)

ex)
- Resolves : #81 (무슨 이슈를 해결했는지)




