### PR TITLE
[feat] : 매물 탭 메인화면 위도, 경도에 따른 반경 2km 매물 아이템

### DIFF
--- a/src/main/java/backend/zip/controller/itemtab/ItemTabController.java
+++ b/src/main/java/backend/zip/controller/itemtab/ItemTabController.java
@@ -1,0 +1,34 @@
+package backend.zip.controller.itemtab;
+
+import backend.zip.domain.broker.BrokerItem;
+import backend.zip.dto.brokeritem.response.BrokerItemResponse;
+import backend.zip.dto.brokeritem.response.BrokerItemShowResponse;
+import backend.zip.dto.main.request.CurrentLocationRequest;
+import backend.zip.global.apipayload.ApiResponse;
+import backend.zip.service.brokeritem.BrokerItemShowService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/main")
+public class ItemTabController {
+    private final BrokerItemShowService brokerItemShowService;
+
+    @Operation(summary = "매물 탭 메인 화면", description = "매물 탭 메인화면에서 현재 위치 주변의 매물 아이템 조회")
+    @GetMapping("/item")
+    public ApiResponse<BrokerItemShowResponse> getBrokerItems(@RequestBody CurrentLocationRequest currentLocationRequest) {
+        List<BrokerItem> brokerItemByCurrentLocation = brokerItemShowService.findBrokerItemByCurrentLocation(currentLocationRequest);
+        BrokerItemShowResponse brokerItemShowResponse = BrokerItemShowResponse.of(brokerItemByCurrentLocation);
+
+        return ApiResponse.onSuccess(brokerItemShowResponse);
+    }
+
+}

--- a/src/main/java/backend/zip/dto/main/request/CurrentLocationRequest.java
+++ b/src/main/java/backend/zip/dto/main/request/CurrentLocationRequest.java
@@ -1,0 +1,14 @@
+package backend.zip.dto.main.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CurrentLocationRequest {
+    private Double x;
+    private Double y;
+
+}

--- a/src/main/java/backend/zip/dto/main/response/BrokerItemListResponseOfMain.java
+++ b/src/main/java/backend/zip/dto/main/response/BrokerItemListResponseOfMain.java
@@ -1,0 +1,34 @@
+//package backend.zip.dto.main.response;
+//
+//import backend.zip.domain.broker.BrokerItem;
+//import backend.zip.domain.enums.ItemStatus;
+//import backend.zip.dto.brokeritem.response.BrokerItemAddressResponse;
+//import backend.zip.dto.brokeritem.response.BrokerItemDetailResponse;
+//import backend.zip.dto.brokeritem.response.BrokerItemOptionResponse;
+//import backend.zip.dto.brokeritem.response.ItemImageResponse;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//
+//import java.util.List;
+//
+//@Getter
+//@Builder
+//@AllArgsConstructor
+//public class BrokerItemListResponseOfMain {
+//    private Long brokerItemId;
+//    private BrokerItemAddressResponse addressResponse;
+//    private BrokerItemDetailResponse detailResponse;
+//    private BrokerItemOptionResponse optionResponse;
+//
+//
+//    public static BrokerItemListResponseOfMain of(List<BrokerItem> brokerItemByCurrentLocation) {
+//        brokerItemByCurrentLocation.stream()
+//                .map(brokerItem -> new BrokerItemListResponseOfMain(
+//                        brokerItem.getBrokerItemId(),
+//
+//
+//                ))
+//    }
+//
+//}

--- a/src/main/java/backend/zip/repository/broker/BrokerItemByCurrentLocationRepository.java
+++ b/src/main/java/backend/zip/repository/broker/BrokerItemByCurrentLocationRepository.java
@@ -1,0 +1,18 @@
+package backend.zip.repository.broker;
+
+import backend.zip.domain.broker.BrokerItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BrokerItemByCurrentLocationRepository extends JpaRepository<BrokerItem, Long> {
+//    @Query(value = "select * from BrokerItem b " +
+////            "join fetch b.brokerOption bo " +
+////            "join fetch b.itemContent " +
+////            "join fetch b.itemImages " +
+//            "where ST_Distance_Sphere(point(:lng, :lat), point(x, y)) <= 2000", nativeQuery = true)
+
+    List<BrokerItem> findBrokerItemsWithinRadius(@Param("lat") Double lat, @Param("lng") Double lng);
+}

--- a/src/main/java/backend/zip/repository/broker/BrokerItemByCurrentLocationRepository.java
+++ b/src/main/java/backend/zip/repository/broker/BrokerItemByCurrentLocationRepository.java
@@ -8,11 +8,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface BrokerItemByCurrentLocationRepository extends JpaRepository<BrokerItem, Long> {
-//    @Query(value = "select * from BrokerItem b " +
-////            "join fetch b.brokerOption bo " +
-////            "join fetch b.itemContent " +
-////            "join fetch b.itemImages " +
-//            "where ST_Distance_Sphere(point(:lng, :lat), point(x, y)) <= 2000", nativeQuery = true)
-
-    List<BrokerItem> findBrokerItemsWithinRadius(@Param("lat") Double lat, @Param("lng") Double lng);
+    @Query(value = "select * from broker_item where ST_Distance_Sphere(point(:lng,:lat),point(x,y)) <= 2000",nativeQuery = true)
+    List<BrokerItem> findBrokerItemsWithinRadius(@Param("lng") Double lng, @Param("lat") Double lat);
 }

--- a/src/main/java/backend/zip/service/brokeritem/BrokerItemShowService.java
+++ b/src/main/java/backend/zip/service/brokeritem/BrokerItemShowService.java
@@ -1,6 +1,7 @@
 package backend.zip.service.brokeritem;
 
 import backend.zip.domain.broker.BrokerItem;
+import backend.zip.dto.main.request.CurrentLocationRequest;
 
 import java.util.List;
 import java.util.Set;
@@ -15,4 +16,6 @@ public interface BrokerItemShowService {
     Set<String> findDongOfBrokerItem(Long userId);
 
     List<BrokerItem> findBrokerItemSortedByDong(String dong);
+
+    List<BrokerItem> findBrokerItemByCurrentLocation(CurrentLocationRequest currentLocationRequest);
 }

--- a/src/main/java/backend/zip/service/brokeritem/BrokerItemShowServiceImpl.java
+++ b/src/main/java/backend/zip/service/brokeritem/BrokerItemShowServiceImpl.java
@@ -2,10 +2,12 @@ package backend.zip.service.brokeritem;
 
 import backend.zip.domain.broker.BrokerItem;
 import backend.zip.domain.user.User;
+import backend.zip.dto.main.request.CurrentLocationRequest;
 import backend.zip.global.exception.brokeritem.BrokerItemException;
 import backend.zip.global.exception.user.UserException;
 import backend.zip.global.status.ErrorStatus;
 import backend.zip.repository.UserRepository;
+import backend.zip.repository.broker.BrokerItemByCurrentLocationRepository;
 import backend.zip.repository.broker.BrokerItemRepository;
 import backend.zip.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import static backend.zip.domain.enums.Role.ROLE_USER;
 public class BrokerItemShowServiceImpl implements BrokerItemShowService {
     private final BrokerItemRepository brokerItemRepository;
     private final UserRepository userRepository;
+    private final BrokerItemByCurrentLocationRepository brokerItemByCurrentLocationRepository;
 
     @Override
     public List<BrokerItem> findBrokerItemList(Long userId) {
@@ -69,5 +72,12 @@ public class BrokerItemShowServiceImpl implements BrokerItemShowService {
     public List<BrokerItem> findBrokerItemSortedByDong(String dong) {
         List<BrokerItem> findAllBrokerItemByDong = brokerItemRepository.findAllByDong(dong);
         return findAllBrokerItemByDong;
+    }
+
+    @Override
+    public List<BrokerItem> findBrokerItemByCurrentLocation(CurrentLocationRequest currentLocationRequest) {
+        return brokerItemByCurrentLocationRepository.findBrokerItemsWithinRadius(currentLocationRequest.getX(),
+                currentLocationRequest.getY()
+        );
     }
 }


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 매물 탭 페이지에서 현재 사용자 위치의 위도,경도 값을 받아 반경 2km의 매물 아이템을 반환해줌

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #69 

---

### 🎸 기타 사항 or 추가 코멘트




